### PR TITLE
Fix uptime calculation

### DIFF
--- a/cc_diagnostics/utils/system_info.py
+++ b/cc_diagnostics/utils/system_info.py
@@ -1,4 +1,5 @@
 import platform
+import time
 import psutil
 
 
@@ -8,5 +9,5 @@ def get_system_info():
         "CPU": platform.processor(),
         "Cores": psutil.cpu_count(logical=True),
         "RAM_GB": round(psutil.virtual_memory().total / 1e9, 2),
-        "Uptime_Hours": round(psutil.boot_time(), 2),
+        "Uptime_Hours": round((time.time() - psutil.boot_time()) / 3600, 2),
     }

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import time
+import psutil
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from cc_diagnostics.utils.system_info import get_system_info
+
+def test_uptime_hours(monkeypatch):
+    fake_boot = 1000
+    fake_time = 1000 + 7200  # 2 hours later
+    monkeypatch.setattr(psutil, "boot_time", lambda: fake_boot)
+    monkeypatch.setattr(time, "time", lambda: fake_time)
+    info = get_system_info()
+    assert info["Uptime_Hours"] == 2.0
+


### PR DESCRIPTION
## Summary
- compute system uptime in hours
- test uptime calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bb00d85c8328b9ba10746a889357