### PR TITLE
Add storage health and report parser tests

### DIFF
--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cc_diagnostics.output_parser import interpret_report
+
+
+def test_interpret_report_ok():
+    report = {
+        "system": {"RAM_GB": 16},
+        "storage": {"used_percent": 50},
+    }
+    summary = interpret_report(report)
+    assert summary["status"] == "OK"
+    assert summary["warnings"] == []
+    assert summary["recommendations"] == []
+
+
+def test_interpret_report_warns():
+    report = {
+        "system": {"RAM_GB": 4},
+        "storage": {"used_percent": 95},
+    }
+    summary = interpret_report(report)
+    assert summary["status"] == "WARN"
+    assert "Low Memory" in summary["warnings"]
+    assert "Disk Almost Full" in summary["warnings"]
+    assert "Recommend upgrading RAM" in summary["recommendations"]
+    assert "Free up space or upgrade drive" in summary["recommendations"]

--- a/tests/test_storage_health.py
+++ b/tests/test_storage_health.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from psutil._common import sdiskusage, sdiskpart
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cc_diagnostics.utils import storage_health
+
+
+def test_check_disk_health(monkeypatch):
+    usage = sdiskusage(total=2_000_000_000, used=500_000_000, free=1_500_000_000, percent=25.0)
+    monkeypatch.setattr(storage_health.psutil, "disk_usage", lambda path: usage)
+
+    parts = [
+        sdiskpart(device="/dev/sda1", mountpoint="/", fstype="ext4", opts=""),
+        sdiskpart(device="/dev/sda1", mountpoint="/home", fstype="ext4", opts=""),
+    ]
+    monkeypatch.setattr(storage_health.psutil, "disk_partitions", lambda all=False: parts)
+    monkeypatch.setattr(storage_health, "_collect_smart_status", lambda dev: "PASSED")
+
+    info = storage_health.check_disk_health()
+    assert info["total_gb"] == 2.0
+    assert info["free_gb"] == 1.5
+    assert info["used_percent"] == 25.0
+    assert info["smart"] == {"/dev/sda1": "PASSED"}


### PR DESCRIPTION
## Summary
- add pytest for `check_disk_health`
- add pytest for `interpret_report`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c191e7f48328a1632a786160e222