### PR TITLE
Add CLI argument parsing to diagnostics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ This installs the `psutil` and `wmi` packages.
 3. Run a test scan:
 ```bash
 python -m cc_diagnostics.diagnostics
+python -m cc_diagnostics.diagnostics --help
 ```
+
+The script accepts `--output-dir` to change where the JSON report is saved and
+`--verbose` to print progress details.
 
 ---
 

--- a/cc_diagnostics/diagnostics.py
+++ b/cc_diagnostics/diagnostics.py
@@ -1,18 +1,48 @@
+"""Command-line entry point for running diagnostics."""
+
+import argparse
 import json
 import os
 from datetime import datetime
+from typing import Sequence
 
-from utils.system_info import get_system_info
-from utils.storage_health import check_disk_health
-from utils.win11_check import check_windows11_compat
-from utils.temperature import get_temperatures
-from output_parser import interpret_report
+from cc_diagnostics.utils.system_info import get_system_info
+from cc_diagnostics.utils.storage_health import check_disk_health
+from cc_diagnostics.utils.win11_check import check_windows11_compat
+from cc_diagnostics.utils.temperature import get_temperatures
+from cc_diagnostics.output_parser import interpret_report
 
 
 LOG_DIR = os.path.join(os.path.dirname(__file__), "logs", "diagnostics")
 
 
-def main():
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Return parsed CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Run system diagnostics and write a JSON report."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=LOG_DIR,
+        help="Directory to write diagnostic report JSON.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print progress information to stdout.",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    opts = parse_args(argv)
+
+    log_dir = os.path.abspath(opts.output_dir)
+
+    if opts.verbose:
+        print(f"Using output directory: {log_dir}")
+
     report = {
         "timestamp": datetime.now().isoformat(),
         "system": get_system_info(),
@@ -24,15 +54,15 @@ def main():
     summary = interpret_report(report)
     report.update(summary)
 
-    os.makedirs(LOG_DIR, exist_ok=True)
-    with open(
-        os.path.join(
-            LOG_DIR,
-            f"diagnostic_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
-        ),
-        "w",
-    ) as f:
+    os.makedirs(log_dir, exist_ok=True)
+    out_file = os.path.join(
+        log_dir, f"diagnostic_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    )
+    with open(out_file, "w") as f:
         json.dump(report, f, indent=2)
+
+    if opts.verbose:
+        print(f"Report written to {out_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `parse_args` in `diagnostics.py`
- add `--output-dir` and `--verbose` options
- enhance README with basic CLI usage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m cc_diagnostics.diagnostics --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6886c5833fcc8328a979874266acd9cf