### PR TITLE
Add hostname and user info

### DIFF
--- a/cc_diagnostics/utils/system_info.py
+++ b/cc_diagnostics/utils/system_info.py
@@ -1,5 +1,7 @@
 import platform
 import time
+import socket
+import getpass
 import psutil
 
 
@@ -10,4 +12,6 @@ def get_system_info():
         "Cores": psutil.cpu_count(logical=True),
         "RAM_GB": round(psutil.virtual_memory().total / 1e9, 2),
         "Uptime_Hours": round((time.time() - psutil.boot_time()) / 3600, 2),
+        "Hostname": socket.gethostname(),
+        "User": getpass.getuser(),
     }

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -2,6 +2,8 @@ import os
 import sys
 import time
 import psutil
+import socket
+import getpass
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from cc_diagnostics.utils.system_info import get_system_info
@@ -13,4 +15,12 @@ def test_uptime_hours(monkeypatch):
     monkeypatch.setattr(time, "time", lambda: fake_time)
     info = get_system_info()
     assert info["Uptime_Hours"] == 2.0
+
+
+def test_hostname_and_user(monkeypatch):
+    monkeypatch.setattr(socket, "gethostname", lambda: "testhost")
+    monkeypatch.setattr(getpass, "getuser", lambda: "testuser")
+    info = get_system_info()
+    assert info["Hostname"] == "testhost"
+    assert info["User"] == "testuser"
 


### PR DESCRIPTION
## Summary
- record hostname and username in system info
- test for hostname/user information

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c7d769208328b8da04af0fa6e1dd