### PR TITLE
Add progress events and GUI progress bar

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -13,11 +13,18 @@ from cc_diagnostics import diagnostics
 class DiagnosticController(QObject):
     """Expose diagnostics functionality to QML."""
 
+    progress = Signal(int, str)
+    log = Signal(str)
     completed = Signal(str)
 
     @Slot()
     def runScan(self) -> None:
-        diagnostics.main([])
+        def cb(pct: float, msg: str) -> None:
+            percent = int(pct * 100)
+            self.progress.emit(percent, msg)
+            self.log.emit(msg)
+
+        diagnostics.main([], progress_callback=cb)
         self.completed.emit("Scan complete")
 
 

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -8,6 +8,9 @@ ApplicationWindow {
     height: 300
     title: qsTr("CC Diagnostics")
 
+    property int progressValue: 0
+    property string logText: ""
+
     Column {
         anchors.centerIn: parent
         spacing: 20
@@ -17,9 +20,43 @@ ApplicationWindow {
             text: qsTr("Ready to scan")
         }
 
+        ProgressBar {
+            id: bar
+            from: 0
+            to: 100
+            value: root.progressValue
+            width: 300
+        }
+
         Button {
             text: qsTr("Run Scan")
-            onClicked: diagnostics.runScan()
+            onClicked: {
+                root.progressValue = 0
+                root.logText = ""
+                diagnostics.runScan()
+            }
+        }
+
+        TextArea {
+            id: logArea
+            text: root.logText
+            readOnly: true
+            width: 350
+            height: 120
+        }
+    }
+
+    Connections {
+        target: diagnostics
+        function onProgress(percent, message) {
+            root.progressValue = percent
+            root.logText += message + "\n"
+        }
+        function onLog(message) {
+            root.logText += message + "\n"
+        }
+        function onCompleted(msg) {
+            statusLabel.text = msg
         }
     }
 }


### PR DESCRIPTION
## Summary
- emit progress via callback in `diagnostics.main`
- hook new progress and log signals in `DiagnosticController`
- display a progress bar and log view in QML UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882c12b6848328899d22f523a822bf