### PR TITLE
Add HTML report export feature

### DIFF
--- a/cc_diagnostics/__init__.py
+++ b/cc_diagnostics/__init__.py
@@ -4,4 +4,9 @@ __version__ = "0.1.0"
 
 __all__ = [
     "__version__",
+    "diagnostics",
+    "output_parser",
+    "report_renderer",
 ]
+
+from . import diagnostics, output_parser, report_renderer  # noqa: E402

--- a/cc_diagnostics/report_renderer.py
+++ b/cc_diagnostics/report_renderer.py
@@ -1,0 +1,39 @@
+"""Render diagnostic reports to HTML using Jinja2."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+TEMPLATE_DIR = Path(__file__).parent / "report_templates"
+LOG_DIR = Path(__file__).parent / "logs" / "diagnostics"
+
+_env = Environment(
+    loader=FileSystemLoader(TEMPLATE_DIR),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+
+def render_html_report(report: dict[str, Any], output_path: str | Path, template_name: str = "default.html") -> str:
+    """Render ``report`` to ``output_path`` using ``template_name``."""
+    template = _env.get_template(template_name)
+    html = template.render(report=report)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html, encoding="utf-8")
+    return str(out)
+
+
+def export_latest_report(output_dir: str | Path, log_dir: str | Path | None = None, template_name: str = "default.html") -> str:
+    """Render the newest JSON report in ``log_dir`` to ``output_dir``."""
+    log_dir = Path(log_dir) if log_dir else LOG_DIR
+    latest_json = max(log_dir.glob("diagnostic_*.json"), key=lambda p: p.stat().st_mtime)
+    report = json.loads(latest_json.read_text())
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    html_name = latest_json.with_suffix(".html").name
+    return render_html_report(report, output_dir / html_name, template_name)

--- a/cc_diagnostics/report_templates/default.html
+++ b/cc_diagnostics/report_templates/default.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>Diagnostic Report</title>
+</head>
+<body>
+    <h1>System Report</h1>
+    <p>Status: {{ report.status }}</p>
+    <h2>Warnings</h2>
+    <ul>
+    {% if report.warnings %}
+        {% for warn in report.warnings %}
+        <li>{{ warn }}</li>
+        {% endfor %}
+    {% else %}
+        <li>None</li>
+    {% endif %}
+    </ul>
+</body>
+</html>

--- a/gui.py
+++ b/gui.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QApplication
 from PySide6.QtQml import QQmlApplicationEngine
 
 from cc_diagnostics import diagnostics
+from cc_diagnostics.report_renderer import export_latest_report
 
 
 class DiagnosticController(QObject):
@@ -26,6 +27,15 @@ class DiagnosticController(QObject):
 
         diagnostics.main([], progress_callback=cb)
         self.completed.emit("Scan complete")
+
+    @Slot(str)
+    def exportReport(self, directory: str) -> None:
+        """Export the most recent JSON report to ``directory`` as HTML."""
+        try:
+            path = export_latest_report(directory)
+            self.log.emit(f"Report exported to {path}")
+        except Exception as exc:  # pragma: no cover - user feedback
+            self.log.emit(f"Export failed: {exc}")
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psutil
 wmi
 
 PySide6
+jinja2

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cc_diagnostics.report_renderer import render_html_report, export_latest_report
+
+
+def test_render_html_report(tmp_path):
+    report = {"status": "OK", "warnings": []}
+    out_file = tmp_path / "report.html"
+    render_html_report(report, out_file)
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "OK" in content
+
+
+def test_export_latest_report(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    sample = {"status": "OK", "warnings": []}
+    json_file = log_dir / "diagnostic_1.json"
+    json_file.write_text(json.dumps(sample))
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    result = export_latest_report(out_dir, log_dir=log_dir)
+    assert Path(result).exists()
+

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -37,6 +37,14 @@ ApplicationWindow {
             }
         }
 
+        Button {
+            text: qsTr("Export")
+            onClicked: {
+                var dir = StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+                diagnostics.exportReport(dir)
+            }
+        }
+
         TextArea {
             id: logArea
             text: root.logText


### PR DESCRIPTION
## Summary
- create `report_renderer` module using `jinja2`
- expose new export button in the QML UI
- wire export action to controller
- include `jinja2` in requirements
- tests for HTML export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68882ecd6c14832885c467ca5aec990b