### PR TITLE
Add actionable recommendations to diagnostics UI

### DIFF
--- a/cc_diagnostics/diagnostics.py
+++ b/cc_diagnostics/diagnostics.py
@@ -43,7 +43,7 @@ ProgressCallback = Callable[[float, str], None]
 def main(
     argv: Sequence[str] | None = None,
     progress_callback: ProgressCallback | None = None,
-) -> None:
+) -> dict:
     opts = parse_args(argv)
 
     def emit(progress: float, message: str) -> None:
@@ -87,6 +87,7 @@ def main(
         json.dump(report, f, indent=2)
 
     emit(1.0, f"Report written to {out_file}")
+    return report
 
 
 if __name__ == "__main__":

--- a/cc_diagnostics/output_parser.py
+++ b/cc_diagnostics/output_parser.py
@@ -17,7 +17,12 @@ Returns
 dict
     A summary dictionary with the following structure:
 
-    ``{"status": "OK" | "WARN", "warnings": list[str], "recommendations": list[str]}``
+    ``{"status": "OK" | "WARN", "warnings": list[str], ``
+    ``"recommendations": list[dict]}``
+
+    Each recommendation dictionary provides ``"text"`` describing the
+    suggestion and ``"action"`` as a short identifier that can be used by
+    the UI to offer contextual help or automation.
 """
 
 def interpret_report(report):
@@ -26,11 +31,17 @@ def interpret_report(report):
 
     if report["system"].get("RAM_GB", 0) < 8:
         warnings.append("Low Memory")
-        recommendations.append("Recommend upgrading RAM")
+        recommendations.append({
+            "text": "Recommend upgrading RAM",
+            "action": "upgrade_ram",
+        })
 
     if report["storage"].get("used_percent", 0) > 90:
         warnings.append("Disk Almost Full")
-        recommendations.append("Free up space or upgrade drive")
+        recommendations.append({
+            "text": "Free up space or upgrade drive",
+            "action": "disk_cleanup",
+        })
 
     return {
         "status": "WARN" if warnings else "OK",

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -26,5 +26,9 @@ def test_interpret_report_warns():
     assert summary["status"] == "WARN"
     assert "Low Memory" in summary["warnings"]
     assert "Disk Almost Full" in summary["warnings"]
-    assert "Recommend upgrading RAM" in summary["recommendations"]
-    assert "Free up space or upgrade drive" in summary["recommendations"]
+    texts = [r["text"] for r in summary["recommendations"]]
+    actions = [r["action"] for r in summary["recommendations"]]
+    assert "Recommend upgrading RAM" in texts
+    assert "Free up space or upgrade drive" in texts
+    assert "upgrade_ram" in actions
+    assert "disk_cleanup" in actions

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -10,6 +10,7 @@ ApplicationWindow {
 
     property int progressValue: 0
     property string logText: ""
+    property var recommendationItems: []
 
     Column {
         anchors.centerIn: parent
@@ -52,6 +53,11 @@ ApplicationWindow {
             width: 350
             height: 120
         }
+
+        Recommendations {
+            id: recList
+            items: root.recommendationItems
+        }
     }
 
     Connections {
@@ -65,6 +71,9 @@ ApplicationWindow {
         }
         function onCompleted(msg) {
             statusLabel.text = msg
+        }
+        function onRecommendationsUpdated(list) {
+            root.recommendationItems = list
         }
     }
 }

--- a/ui/Recommendations.qml
+++ b/ui/Recommendations.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import QtQuick.Controls
+
+Column {
+    id: root
+    property var items: []
+    spacing: 6
+
+    Repeater {
+        model: root.items
+        delegate: Row {
+            spacing: 8
+            Text { text: "\ud83d\udca1" } // lightbulb emoji
+            Text { text: modelData.text }
+            Button {
+                text: qsTr("More")
+                visible: modelData.action !== undefined
+                onClicked: diagnostics.runAction(modelData.action)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `interpret_report` to include action identifiers with recommendations
- emit recommendations from `DiagnosticController` to QML and open help links
- display recommendation list in new `Recommendations.qml` component
- show recommendations in `Main.qml`
- return report from diagnostics `main` function
- adjust tests for new recommendation structure

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888301113e48328bf4ab02facf62147