### PR TITLE
Enable optional remote diagnostics

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+  "server_endpoint": ""
+}

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -11,6 +11,8 @@ ApplicationWindow {
     property int progressValue: 0
     property string logText: ""
     property var recommendationItems: []
+    property bool remoteEnabled: false
+    property string uploadStatus: ""
 
     Column {
         anchors.centerIn: parent
@@ -27,6 +29,20 @@ ApplicationWindow {
             to: 100
             value: root.progressValue
             width: 300
+        }
+
+        Row {
+            spacing: 10
+            CheckBox {
+                id: remoteToggle
+                checked: root.remoteEnabled
+                text: qsTr("Remote")
+                onCheckedChanged: {
+                    root.remoteEnabled = checked
+                    diagnostics.setRemoteEnabled(checked)
+                }
+            }
+            Text { text: root.uploadStatus }
         }
 
         Button {
@@ -74,6 +90,9 @@ ApplicationWindow {
         }
         function onRecommendationsUpdated(list) {
             root.recommendationItems = list
+        }
+        function onUploadStatus(status) {
+            root.uploadStatus = status
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `settings.json` to hold a server endpoint
- support `--server-endpoint` flag and helper to POST reports
- surface upload status in `DiagnosticController`
- toggle remote diagnostics in the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888344731b8832887f206a374d45dd1