### PR TITLE
Add report view and loadLatestReport

### DIFF
--- a/tests/test_gui_controller.py
+++ b/tests/test_gui_controller.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gui import DiagnosticController
+from cc_diagnostics import diagnostics
+
+
+def test_load_latest_report(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    old = {"status": "OK"}
+    new = {"status": "WARN", "warnings": ["w"]}
+    old_file = log_dir / "diagnostic_1.json"
+    new_file = log_dir / "diagnostic_2.json"
+    old_file.write_text(json.dumps(old))
+    new_file.write_text(json.dumps(new))
+    monkeypatch.setattr(diagnostics, "LOG_DIR", str(log_dir))
+
+    controller = DiagnosticController()
+    result = controller.loadLatestReport()
+    assert result["status"] == "WARN"
+    assert result["warnings"] == ["w"]
+
+
+def test_load_latest_report_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(diagnostics, "LOG_DIR", str(tmp_path))
+    controller = DiagnosticController()
+    assert controller.loadLatestReport() == {}

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -14,65 +14,84 @@ ApplicationWindow {
     property bool remoteEnabled: false
     property string uploadStatus: ""
 
-    Column {
-        anchors.centerIn: parent
-        spacing: 20
+    StackView {
+        id: stack
+        anchors.fill: parent
+        initialItem: mainPage
+    }
 
-        Text {
-            id: statusLabel
-            text: qsTr("Ready to scan")
-        }
+    Component {
+        id: mainPage
+        Column {
+            anchors.centerIn: parent
+            spacing: 20
 
-        ProgressBar {
-            id: bar
-            from: 0
-            to: 100
-            value: root.progressValue
-            width: 300
-        }
+            Text {
+                id: statusLabel
+                text: qsTr("Ready to scan")
+            }
 
-        Row {
-            spacing: 10
-            CheckBox {
-                id: remoteToggle
-                checked: root.remoteEnabled
-                text: qsTr("Remote")
-                onCheckedChanged: {
-                    root.remoteEnabled = checked
-                    diagnostics.setRemoteEnabled(checked)
+            ProgressBar {
+                id: bar
+                from: 0
+                to: 100
+                value: root.progressValue
+                width: 300
+            }
+
+            Row {
+                spacing: 10
+                CheckBox {
+                    id: remoteToggle
+                    checked: root.remoteEnabled
+                    text: qsTr("Remote")
+                    onCheckedChanged: {
+                        root.remoteEnabled = checked
+                        diagnostics.setRemoteEnabled(checked)
+                    }
+                }
+                Text { text: root.uploadStatus }
+            }
+
+            Button {
+                text: qsTr("Run Scan")
+                icon.name: "play_arrow"
+                onClicked: {
+                    root.progressValue = 0
+                    root.logText = ""
+                    diagnostics.runScan()
                 }
             }
-            Text { text: root.uploadStatus }
-        }
 
-        Button {
-            text: qsTr("Run Scan")
-            onClicked: {
-                root.progressValue = 0
-                root.logText = ""
-                diagnostics.runScan()
+            Button {
+                text: qsTr("Export")
+                icon.name: "save"
+                onClicked: {
+                    var dir = StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+                    diagnostics.exportReport(dir)
+                }
+            }
+
+            TextArea {
+                id: logArea
+                text: root.logText
+                readOnly: true
+                width: 350
+                height: 120
+            }
+
+            Recommendations {
+                id: recList
+                items: root.recommendationItems
             }
         }
+    }
 
-        Button {
-            text: qsTr("Export")
-            onClicked: {
-                var dir = StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
-                diagnostics.exportReport(dir)
-            }
-        }
-
-        TextArea {
-            id: logArea
-            text: root.logText
-            readOnly: true
-            width: 350
-            height: 120
-        }
-
-        Recommendations {
-            id: recList
-            items: root.recommendationItems
+    Component {
+        id: reportPage
+        ReportView {
+            id: reportView
+            onBackRequested: stack.pop()
         }
     }
 
@@ -87,6 +106,8 @@ ApplicationWindow {
         }
         function onCompleted(msg) {
             statusLabel.text = msg
+            reportView.reportData = diagnostics.loadLatestReport()
+            stack.push(reportPage)
         }
         function onRecommendationsUpdated(list) {
             root.recommendationItems = list

--- a/ui/ReportView.qml
+++ b/ui/ReportView.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Page {
+    id: root
+    title: qsTr("Diagnostic Report")
+    signal backRequested()
+    property var reportData: {}
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 12
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+            Label { text: qsTr("Status:") }
+            Text { text: root.reportData.status || ""; font.bold: true }
+        }
+
+        Column {
+            spacing: 4
+            visible: (root.reportData.warnings || []).length > 0
+            Label { text: qsTr("Warnings") ; font.bold: true }
+            Repeater {
+                model: root.reportData.warnings || []
+                delegate: RowLayout {
+                    spacing: 6
+                    Label { text: Material.icons.warning }
+                    Text { text: modelData }
+                }
+            }
+        }
+
+        Recommendations {
+            id: recList
+            items: root.reportData.recommendations || []
+        }
+
+        Button {
+            text: qsTr("Back")
+            icon.name: "arrow_back"
+            onClicked: root.backRequested()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `ReportView.qml` to present diagnostic results
- update `Main.qml` to navigate to the new view
- set `QT_QUICK_CONTROLS_STYLE` to Material and expose a new `loadLatestReport` slot
- add controller tests for loading the newest report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688845a5ce0c83289f8f7e9c6a48bbd2