### PR TITLE
Add settings dialog and updateSetting slot

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cc_diagnostics import diagnostics
+
+
+def test_load_settings(tmp_path, monkeypatch):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text('{"server_endpoint": "http://localhost"}')
+    monkeypatch.setattr(diagnostics, "SETTINGS_FILE", settings_file)
+    assert diagnostics._load_settings()["server_endpoint"] == "http://localhost"
+
+
+def test_update_setting(tmp_path, monkeypatch):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text('{}')
+    monkeypatch.setattr(diagnostics, "SETTINGS_FILE", settings_file)
+    # update controller reference as well
+    from importlib import reload
+    import gui as gui_mod
+    reload(gui_mod)
+    monkeypatch.setattr(gui_mod, "SETTINGS_FILE", settings_file)
+
+    controller = gui_mod.DiagnosticController()
+    controller.updateSetting("server_endpoint", "http://new")
+
+    data = json.loads(settings_file.read_text())
+    assert data["server_endpoint"] == "http://new"

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -14,6 +14,10 @@ ApplicationWindow {
     property bool remoteEnabled: false
     property string uploadStatus: ""
 
+    SettingsDialog {
+        id: settingsDialog
+    }
+
     StackView {
         id: stack
         anchors.fill: parent
@@ -70,6 +74,12 @@ ApplicationWindow {
                     var dir = StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
                     diagnostics.exportReport(dir)
                 }
+            }
+
+            Button {
+                text: qsTr("Settings")
+                icon.name: "settings"
+                onClicked: settingsDialog.open()
             }
 
             TextArea {

--- a/ui/SettingsDialog.qml
+++ b/ui/SettingsDialog.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import QtQuick.Controls
+
+Dialog {
+    id: root
+    modal: true
+    property string serverEndpoint: ""
+    property bool remoteUpload: false
+
+    title: qsTr("Settings")
+
+    Column {
+        spacing: 10
+        anchors.fill: parent
+        anchors.margins: 20
+
+        TextField {
+            id: endpointField
+            placeholderText: qsTr("Server Endpoint")
+            text: root.serverEndpoint
+        }
+
+        CheckBox {
+            id: remoteCheck
+            text: qsTr("Enable Remote Upload")
+            checked: root.remoteUpload
+        }
+
+        Row {
+            spacing: 8
+            Button {
+                text: qsTr("Save")
+                onClicked: {
+                    diagnostics.updateSetting("server_endpoint", endpointField.text)
+                    diagnostics.updateSetting("remote_upload", remoteCheck.checked)
+                    root.close()
+                }
+            }
+            Button {
+                text: qsTr("Cancel")
+                onClicked: root.close()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SettingsDialog component for configuring remote settings
- expose `updateSetting` slot in `DiagnosticController`
- integrate dialog in `Main.qml`
- test settings load and update functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68885e6006748328a5a39394d2e05da1