### PR TITLE
Add PDF report export option

### DIFF
--- a/cc_diagnostics/report_renderer.py
+++ b/cc_diagnostics/report_renderer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+import pdfkit
 
 TEMPLATE_DIR = Path(__file__).parent / "report_templates"
 LOG_DIR = Path(__file__).parent / "logs" / "diagnostics"
@@ -27,13 +28,35 @@ def render_html_report(report: dict[str, Any], output_path: str | Path, template
     return str(out)
 
 
-def export_latest_report(output_dir: str | Path, log_dir: str | Path | None = None, template_name: str = "default.html") -> str:
-    """Render the newest JSON report in ``log_dir`` to ``output_dir``."""
+def render_pdf_report(report: dict[str, Any], output_path: str | Path, template_name: str = "default.html") -> str:
+    """Render ``report`` to ``output_path`` as PDF using ``template_name``."""
+    template = _env.get_template(template_name)
+    html = template.render(report=report)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    pdfkit.from_string(html, str(out))
+    return str(out)
+
+
+def export_latest_report(
+    output_dir: str | Path,
+    log_dir: str | Path | None = None,
+    template_name: str = "default.html",
+    fmt: str = "html",
+) -> str:
+    """Render the newest JSON report in ``log_dir`` to ``output_dir`` as ``fmt``."""
     log_dir = Path(log_dir) if log_dir else LOG_DIR
     latest_json = max(log_dir.glob("diagnostic_*.json"), key=lambda p: p.stat().st_mtime)
     report = json.loads(latest_json.read_text())
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    html_name = latest_json.with_suffix(".html").name
-    return render_html_report(report, output_dir / html_name, template_name)
+    base_name = latest_json.stem
+
+    if fmt.lower() == "pdf":
+        out_path = output_dir / f"{base_name}.pdf"
+        return render_pdf_report(report, out_path, template_name)
+    else:
+        out_path = output_dir / f"{base_name}.html"
+        return render_html_report(report, out_path, template_name)

--- a/gui.py
+++ b/gui.py
@@ -75,11 +75,11 @@ class DiagnosticController(QObject):
     def setRemoteEnabled(self, enabled: bool) -> None:
         self._remote_enabled = enabled
 
-    @Slot(str)
-    def exportReport(self, directory: str) -> None:
-        """Export the most recent JSON report to ``directory`` as HTML."""
+    @Slot(str, str)
+    def exportReport(self, directory: str, fmt: str = "html") -> None:
+        """Export the most recent JSON report to ``directory`` as HTML or PDF."""
         try:
-            path = export_latest_report(directory)
+            path = export_latest_report(directory, fmt=fmt)
             self.log.emit(f"Report exported to {path}")
         except Exception as exc:  # pragma: no cover - user feedback
             self.log.emit(f"Export failed: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "wmi",
     "PySide6",
     "jinja2",
+    "pdfkit",
 ]
 requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ wmi
 
 PySide6
 jinja2
+pdfkit

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from cc_diagnostics.report_renderer import render_html_report, export_latest_report
+from cc_diagnostics.report_renderer import (
+    render_html_report,
+    render_pdf_report,
+    export_latest_report,
+)
 
 
 def test_render_html_report(tmp_path):
@@ -26,5 +30,24 @@ def test_export_latest_report(tmp_path):
     out_dir = tmp_path / "out"
     out_dir.mkdir()
     result = export_latest_report(out_dir, log_dir=log_dir)
+    assert Path(result).exists()
+
+
+def test_render_pdf_report(tmp_path):
+    report = {"status": "OK"}
+    out_file = tmp_path / "report.pdf"
+    render_pdf_report(report, out_file)
+    assert out_file.exists()
+
+
+def test_export_latest_report_pdf(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    sample = {"status": "OK"}
+    json_file = log_dir / "diagnostic_1.json"
+    json_file.write_text(json.dumps(sample))
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    result = export_latest_report(out_dir, log_dir=log_dir, fmt="pdf")
     assert Path(result).exists()
 

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -13,6 +13,7 @@ ApplicationWindow {
     property var recommendationItems: []
     property bool remoteEnabled: false
     property string uploadStatus: ""
+    property string exportFormat: "html"
 
     SettingsDialog {
         id: settingsDialog
@@ -67,12 +68,20 @@ ApplicationWindow {
                 }
             }
 
+            ComboBox {
+                id: formatBox
+                model: ["HTML", "PDF"]
+                onActivated: {
+                    root.exportFormat = currentIndex === 0 ? "html" : "pdf"
+                }
+            }
+
             Button {
                 text: qsTr("Export")
                 icon.name: "save"
                 onClicked: {
                     var dir = StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
-                    diagnostics.exportReport(dir)
+                    diagnostics.exportReport(dir, root.exportFormat)
                 }
             }
 


### PR DESCRIPTION
## Summary
- add pdfkit dependency for PDF rendering
- implement PDF report rendering in `report_renderer`
- update `DiagnosticController` to handle HTML/PDF selection
- add export format control to the QML UI
- test PDF generation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888642e2e0883288c61a65a62aa754b