### PR TITLE
Add theme toggle and status card UI components

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -53,6 +53,12 @@ class DiagnosticController(QObject):
             "storage": report.get("storage", {}),
         }
 
+    @Slot(str, result="QVariant")
+    def loadSetting(self, key: str):
+        """Return value of ``key`` from settings.json if present."""
+        settings = _load_settings()
+        return settings.get(key)
+
     @Slot()
     def runScan(self) -> None:
         def cb(pct: float, msg: str) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,3 +29,16 @@ def test_update_setting(tmp_path, monkeypatch):
 
     data = json.loads(settings_file.read_text())
     assert data["server_endpoint"] == "http://new"
+
+
+def test_load_setting(tmp_path, monkeypatch):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text('{"dark_mode": true}')
+    monkeypatch.setattr(diagnostics, "SETTINGS_FILE", settings_file)
+    from importlib import reload
+    import gui as gui_mod
+    reload(gui_mod)
+    monkeypatch.setattr(gui_mod, "SETTINGS_FILE", settings_file)
+
+    controller = gui_mod.DiagnosticController()
+    assert controller.loadSetting("dark_mode") is True

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -1,5 +1,7 @@
 import QtQuick
 import QtQuick.Controls
+import "Styles.qml" as Styles
+import "."
 
 ApplicationWindow {
     id: root
@@ -7,6 +9,15 @@ ApplicationWindow {
     width: 400
     height: 300
     title: qsTr("CC Diagnostics")
+    property bool darkMode: false
+    Material.theme: darkMode ? Material.Dark : Material.Light
+
+    Component.onCompleted: {
+        var val = diagnostics.loadSetting("dark_mode")
+        if (val !== undefined && val !== null) {
+            darkMode = val
+        }
+    }
 
     property int progressValue: 0
     property string logText: ""
@@ -29,34 +40,42 @@ ApplicationWindow {
         id: mainPage
         Column {
             anchors.centerIn: parent
-            spacing: 20
+            spacing: Styles.spacingLarge
 
-            Text {
-                id: statusLabel
-                text: qsTr("Ready to scan")
-            }
+            StatusCard {
+                width: 360
+                content: Column {
+                    spacing: Styles.spacingMedium
+                    Text {
+                        id: statusLabel
+                        text: qsTr("Ready to scan")
+                    }
 
-            ProgressBar {
-                id: bar
-                from: 0
-                to: 100
-                value: root.progressValue
-                width: 300
-            }
+                    ProgressBar {
+                        id: bar
+                        from: 0
+                        to: 100
+                        value: root.progressValue
+                        width: 300
+                    }
 
-            Row {
-                spacing: 10
-                CheckBox {
-                    id: remoteToggle
-                    checked: root.remoteEnabled
-                    text: qsTr("Remote")
-                    onCheckedChanged: {
-                        root.remoteEnabled = checked
-                        diagnostics.setRemoteEnabled(checked)
+                    Row {
+                        spacing: Styles.spacingMedium
+                        CheckBox {
+                            id: remoteToggle
+                            checked: root.remoteEnabled
+                            text: qsTr("Remote")
+                            onCheckedChanged: {
+                                root.remoteEnabled = checked
+                                diagnostics.setRemoteEnabled(checked)
+                            }
+                        }
+                        Text { text: root.uploadStatus }
                     }
                 }
-                Text { text: root.uploadStatus }
             }
+
+
 
             Button {
                 text: qsTr("Run Scan")

--- a/ui/SettingsDialog.qml
+++ b/ui/SettingsDialog.qml
@@ -6,6 +6,13 @@ Dialog {
     modal: true
     property string serverEndpoint: ""
     property bool remoteUpload: false
+    property bool darkMode: false
+
+    onOpened: {
+        darkCheck.checked = root.parent.darkMode
+        endpointField.text = root.serverEndpoint
+        remoteCheck.checked = root.remoteUpload
+    }
 
     title: qsTr("Settings")
 
@@ -26,6 +33,12 @@ Dialog {
             checked: root.remoteUpload
         }
 
+        CheckBox {
+            id: darkCheck
+            text: qsTr("Dark Mode")
+            checked: root.darkMode
+        }
+
         Row {
             spacing: 8
             Button {
@@ -33,6 +46,9 @@ Dialog {
                 onClicked: {
                     diagnostics.updateSetting("server_endpoint", endpointField.text)
                     diagnostics.updateSetting("remote_upload", remoteCheck.checked)
+                    diagnostics.updateSetting("dark_mode", darkCheck.checked)
+                    root.darkMode = darkCheck.checked
+                    root.parent.darkMode = darkCheck.checked
                     root.close()
                 }
             }

--- a/ui/StatusCard.qml
+++ b/ui/StatusCard.qml
@@ -1,0 +1,19 @@
+import QtQuick
+import QtQuick.Controls
+import "Styles.qml" as Styles
+
+Rectangle {
+    id: card
+    radius: 6
+    color: Qt.application.palette.base
+    border.color: Styles.primaryColor
+
+    default property alias content: contentArea.data
+
+    Column {
+        id: contentArea
+        anchors.fill: parent
+        anchors.margins: Styles.spacingMedium
+        spacing: Styles.spacingSmall
+    }
+}

--- a/ui/Styles.qml
+++ b/ui/Styles.qml
@@ -1,0 +1,9 @@
+import QtQuick
+import QtQuick.Controls
+
+QtObject {
+    readonly property int spacingSmall: 4
+    readonly property int spacingMedium: 8
+    readonly property int spacingLarge: 16
+    readonly property color primaryColor: Material.color(Material.Blue)
+}


### PR DESCRIPTION
## Summary
- introduce `StatusCard` and `Styles` components
- enable dark mode toggle in settings dialog
- expose `loadSetting` from `DiagnosticController`
- use new components in `Main.qml`
- test new controller method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688868657f248328a80bc0c43be613eb