### PR TITLE
Add loading skeletons and controller signal

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -25,6 +25,7 @@ class DiagnosticController(QObject):
     completed = Signal(str)
     recommendationsUpdated = Signal(list)
     uploadStatus = Signal(str)
+    loading = Signal(bool)
 
     def __init__(self) -> None:
         super().__init__()
@@ -61,6 +62,7 @@ class DiagnosticController(QObject):
 
     @Slot()
     def runScan(self) -> None:
+        self.loading.emit(True)
         def cb(pct: float, msg: str) -> None:
             percent = int(pct * 100)
             self.progress.emit(percent, msg)
@@ -76,6 +78,7 @@ class DiagnosticController(QObject):
         self.recommendationsUpdated.emit(report.get("recommendations", []))
         self.completed.emit("Scan complete")
         self.uploadStatus.emit(report.get("upload_status", "disabled"))
+        self.loading.emit(False)
 
     @Slot(bool)
     def setRemoteEnabled(self, enabled: bool) -> None:

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -25,6 +25,7 @@ ApplicationWindow {
     property bool remoteEnabled: false
     property string uploadStatus: ""
     property string exportFormat: "html"
+    property bool scanRunning: false
 
     SettingsDialog {
         id: settingsDialog
@@ -44,6 +45,7 @@ ApplicationWindow {
 
             StatusCard {
                 width: 360
+                loading: root.scanRunning
                 content: Column {
                     spacing: Styles.spacingMedium
                     Text {
@@ -83,6 +85,8 @@ ApplicationWindow {
                 onClicked: {
                     root.progressValue = 0
                     root.logText = ""
+                    root.scanRunning = true
+                    reportView.loading = true
                     diagnostics.runScan()
                 }
             }
@@ -146,12 +150,19 @@ ApplicationWindow {
             statusLabel.text = msg
             reportView.reportData = diagnostics.loadLatestReport()
             stack.push(reportPage)
+            root.scanRunning = false
         }
         function onRecommendationsUpdated(list) {
             root.recommendationItems = list
         }
         function onUploadStatus(status) {
             root.uploadStatus = status
+        }
+        function onLoading(flag) {
+            root.scanRunning = flag
+            if (flag) {
+                reportView.loading = true
+            }
         }
     }
 }

--- a/ui/ReportView.qml
+++ b/ui/ReportView.qml
@@ -7,11 +7,17 @@ Page {
     title: qsTr("Diagnostic Report")
     signal backRequested()
     property var reportData: {}
+    property bool loading: true
+
+    onReportDataChanged: loading = false
 
     ColumnLayout {
+        id: contentArea
         anchors.fill: parent
         anchors.margins: 20
         spacing: 12
+        opacity: root.loading ? 0 : 1
+        Behavior on opacity { NumberAnimation { duration: 200 } }
 
         RowLayout {
             Layout.fillWidth: true
@@ -44,5 +50,13 @@ Page {
             icon.name: "arrow_back"
             onClicked: root.backRequested()
         }
+    }
+
+    BusyIndicator {
+        anchors.centerIn: parent
+        running: root.loading
+        visible: root.loading
+        opacity: root.loading ? 1 : 0
+        Behavior on opacity { NumberAnimation { duration: 200 } }
     }
 }

--- a/ui/StatusCard.qml
+++ b/ui/StatusCard.qml
@@ -8,6 +8,8 @@ Rectangle {
     color: Qt.application.palette.base
     border.color: Styles.primaryColor
 
+    property bool loading: false
+
     default property alias content: contentArea.data
 
     Column {
@@ -15,5 +17,22 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: Styles.spacingMedium
         spacing: Styles.spacingSmall
+        opacity: card.loading ? 0 : 1
+        Behavior on opacity { NumberAnimation { duration: 200 } }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 6
+        color: Qt.lighter(Styles.primaryColor, 1.5)
+        opacity: card.loading ? 1 : 0
+        visible: opacity > 0
+        Behavior on opacity { NumberAnimation { duration: 200 } }
+
+        BusyIndicator {
+            anchors.centerIn: parent
+            running: card.loading
+            visible: card.loading
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show busy indicator in `StatusCard` when loading
- add skeleton loader in `ReportView`
- emit `loading` signal from controller while a scan runs
- hook up `loading` state in `Main.qml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886d80eecc832887106af7ca452c45