### PR TITLE
Refactor QML to use design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ cc_diagnostics/
 
 ---
 
+## 🎨 Design Tokens
+
+The `ui/Styles.qml` file centralizes colors, spacing and font sizes used across the UI.
+
+| Token | Description |
+|-------|-------------|
+| `spacingSmall` | Small spacing (4 px) |
+| `spacingMedium` | Default spacing (8 px) |
+| `spacingLarge` | Large spacing (16 px) |
+| `fontFamily` | Base font family |
+| `fontSizeSmall` | Small text size |
+| `fontSizeMedium` | Regular text size |
+| `fontSizeLarge` | Heading text size |
+| `primaryColor` | Main accent color |
+| `secondaryColor` | Secondary accent |
+| `tertiaryColor` | Success/tertiary color |
+| `elevationLow/Medium/High` | Shadow elevation levels |
+| `overlayOpacity` | Opacity for busy overlays |
+| `disabledOpacity` | Opacity for disabled content |
+
+---
+
 ## 📦 Setup
 
 1. Create and activate a virtual environment:

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -50,6 +50,9 @@ ApplicationWindow {
                     Text {
                         id: statusLabel
                         text: qsTr("Ready to scan")
+                        font.family: Styles.fontFamily
+                        font.pixelSize: Styles.fontSizeLarge
+                        color: Styles.primaryColor
                     }
 
                     ProgressBar {
@@ -66,12 +69,19 @@ ApplicationWindow {
                             id: remoteToggle
                             checked: root.remoteEnabled
                             text: qsTr("Remote")
+                            font.family: Styles.fontFamily
+                            font.pixelSize: Styles.fontSizeMedium
                             onCheckedChanged: {
                                 root.remoteEnabled = checked
                                 diagnostics.setRemoteEnabled(checked)
                             }
                         }
-                        Text { text: root.uploadStatus }
+                        Text {
+                            text: root.uploadStatus
+                            font.family: Styles.fontFamily
+                            font.pixelSize: Styles.fontSizeSmall
+                            color: Styles.secondaryColor
+                        }
                     }
                 }
             }
@@ -119,6 +129,8 @@ ApplicationWindow {
                 readOnly: true
                 Layout.fillWidth: true
                 Layout.preferredHeight: 120
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeSmall
             }
 
             Recommendations {

--- a/ui/Recommendations.qml
+++ b/ui/Recommendations.qml
@@ -1,17 +1,27 @@
 import QtQuick
 import QtQuick.Controls
+import "Styles.qml" as Styles
 
 Column {
     id: root
     property var items: []
-    spacing: 6
+    spacing: Styles.spacingSmall
 
     Repeater {
         model: root.items
         delegate: Row {
-            spacing: 8
-            Text { text: "\ud83d\udca1" } // lightbulb emoji
-            Text { text: modelData.text }
+            spacing: Styles.spacingMedium
+            Text {
+                text: "\ud83d\udca1" // lightbulb emoji
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeLarge
+                color: Styles.tertiaryColor
+            }
+            Text {
+                text: modelData.text
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeMedium
+            }
             Button {
                 text: qsTr("More")
                 visible: modelData.action !== undefined

--- a/ui/ReportView.qml
+++ b/ui/ReportView.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "Styles.qml" as Styles
 
 Page {
     id: root
@@ -14,28 +15,52 @@ Page {
     ColumnLayout {
         id: contentArea
         anchors.fill: parent
-        anchors.margins: 20
-        spacing: 12
+        anchors.margins: Styles.spacingLarge
+        spacing: Styles.spacingMedium
         opacity: root.loading ? 0 : 1
         Behavior on opacity { NumberAnimation { duration: 200 } }
 
         RowLayout {
             Layout.fillWidth: true
-            spacing: 8
-            Label { text: qsTr("Status:") }
-            Text { text: root.reportData.status || ""; font.bold: true }
+            spacing: Styles.spacingMedium
+            Label {
+                text: qsTr("Status:")
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeMedium
+            }
+            Text {
+                text: root.reportData.status || ""
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeMedium
+                font.bold: true
+                color: Styles.primaryColor
+            }
         }
 
         Column {
-            spacing: 4
+            spacing: Styles.spacingSmall
             visible: (root.reportData.warnings || []).length > 0
-            Label { text: qsTr("Warnings") ; font.bold: true }
+            Label {
+                text: qsTr("Warnings")
+                font.family: Styles.fontFamily
+                font.pixelSize: Styles.fontSizeMedium
+                font.bold: true
+                color: Styles.secondaryColor
+            }
             Repeater {
                 model: root.reportData.warnings || []
                 delegate: RowLayout {
-                    spacing: 6
-                    Label { text: Material.icons.warning }
-                    Text { text: modelData }
+                    spacing: Styles.spacingSmall
+                    Label {
+                        text: Material.icons.warning
+                        color: Styles.secondaryColor
+                        font.pixelSize: Styles.fontSizeMedium
+                    }
+                    Text {
+                        text: modelData
+                        font.family: Styles.fontFamily
+                        font.pixelSize: Styles.fontSizeSmall
+                    }
                 }
             }
         }
@@ -56,7 +81,7 @@ Page {
         anchors.centerIn: parent
         running: root.loading
         visible: root.loading
-        opacity: root.loading ? 1 : 0
+        opacity: root.loading ? Styles.overlayOpacity : 0
         Behavior on opacity { NumberAnimation { duration: 200 } }
     }
 }

--- a/ui/SettingsDialog.qml
+++ b/ui/SettingsDialog.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import "Styles.qml" as Styles
 
 Dialog {
     id: root
@@ -17,30 +18,36 @@ Dialog {
     title: qsTr("Settings")
 
     Column {
-        spacing: 10
+        spacing: Styles.spacingMedium
         anchors.fill: parent
-        anchors.margins: 20
+        anchors.margins: Styles.spacingLarge
 
         TextField {
             id: endpointField
             placeholderText: qsTr("Server Endpoint")
             text: root.serverEndpoint
+            font.family: Styles.fontFamily
+            font.pixelSize: Styles.fontSizeMedium
         }
 
         CheckBox {
             id: remoteCheck
             text: qsTr("Enable Remote Upload")
             checked: root.remoteUpload
+            font.family: Styles.fontFamily
+            font.pixelSize: Styles.fontSizeMedium
         }
 
         CheckBox {
             id: darkCheck
             text: qsTr("Dark Mode")
             checked: root.darkMode
+            font.family: Styles.fontFamily
+            font.pixelSize: Styles.fontSizeMedium
         }
 
         Row {
-            spacing: 8
+            spacing: Styles.spacingMedium
             Button {
                 text: qsTr("Save")
                 onClicked: {

--- a/ui/StatusCard.qml
+++ b/ui/StatusCard.qml
@@ -17,15 +17,15 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: Styles.spacingMedium
         spacing: Styles.spacingSmall
-        opacity: card.loading ? 0 : 1
+        opacity: card.loading ? Styles.disabledOpacity : 1
         Behavior on opacity { NumberAnimation { duration: 200 } }
     }
 
     Rectangle {
         anchors.fill: parent
         radius: 6
-        color: Qt.lighter(Styles.primaryColor, 1.5)
-        opacity: card.loading ? 1 : 0
+        color: Qt.lighter(Styles.secondaryColor, 1.5)
+        opacity: card.loading ? Styles.overlayOpacity : 0
         visible: opacity > 0
         Behavior on opacity { NumberAnimation { duration: 200 } }
 

--- a/ui/Styles.qml
+++ b/ui/Styles.qml
@@ -6,4 +6,17 @@ QtObject {
     readonly property int spacingMedium: 8
     readonly property int spacingLarge: 16
     readonly property color primaryColor: Material.color(Material.Blue)
+    readonly property color secondaryColor: Material.color(Material.Grey)
+    readonly property color tertiaryColor: Material.color(Material.Green)
+
+    readonly property string fontFamily: "Segoe UI"
+    readonly property int fontSizeSmall: 12
+    readonly property int fontSizeMedium: 14
+    readonly property int fontSizeLarge: 18
+
+    readonly property real elevationLow: 2
+    readonly property real elevationMedium: 6
+    readonly property real elevationHigh: 12
+    readonly property real overlayOpacity: 0.6
+    readonly property real disabledOpacity: 0.3
 }


### PR DESCRIPTION
## Summary
- expand `Styles.qml` with fonts, colors and opacity constants
- update QML components to consume the tokens
- document design tokens in the README

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6888821c66e083288aacf87faaa35547