### PR TITLE
Improve error handling for missing diagnostic reports

### DIFF
--- a/cc_diagnostics/report_renderer.py
+++ b/cc_diagnostics/report_renderer.py
@@ -47,7 +47,10 @@ def export_latest_report(
 ) -> str:
     """Render the newest JSON report in ``log_dir`` to ``output_dir`` as ``fmt``."""
     log_dir = Path(log_dir) if log_dir else LOG_DIR
-    latest_json = max(log_dir.glob("diagnostic_*.json"), key=lambda p: p.stat().st_mtime)
+    json_files = list(log_dir.glob("diagnostic_*.json"))
+    if not json_files:
+        raise FileNotFoundError(f"No diagnostic reports found in {log_dir}")
+    latest_json = max(json_files, key=lambda p: p.stat().st_mtime)
     report = json.loads(latest_json.read_text())
 
     output_dir = Path(output_dir)

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -51,3 +51,16 @@ def test_export_latest_report_pdf(tmp_path):
     result = export_latest_report(out_dir, log_dir=log_dir, fmt="pdf")
     assert Path(result).exists()
 
+
+def test_export_latest_report_no_files(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    try:
+        export_latest_report(out_dir, log_dir=log_dir)
+    except FileNotFoundError as e:
+        assert "No diagnostic reports found" in str(e)
+    else:
+        assert False, "Expected FileNotFoundError"
+


### PR DESCRIPTION
## Summary
- raise a user-friendly `FileNotFoundError` when no diagnostic logs exist
- test export_latest_report with no logs present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688886b09e9c8328ae484d082c077634