### PR TITLE
Handle missing wkhtmltopdf

### DIFF
--- a/cc_diagnostics/report_renderer.py
+++ b/cc_diagnostics/report_renderer.py
@@ -35,7 +35,10 @@ def render_pdf_report(report: dict[str, Any], output_path: str | Path, template_
 
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
-    pdfkit.from_string(html, str(out))
+    try:
+        pdfkit.from_string(html, str(out))
+    except OSError as e:
+        raise OSError("wkhtmltopdf not installed") from e
     return str(out)
 
 

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -10,6 +10,7 @@ from cc_diagnostics.report_renderer import (
     render_pdf_report,
     export_latest_report,
 )
+import cc_diagnostics.report_renderer as report_renderer
 
 
 def test_render_html_report(tmp_path):
@@ -63,4 +64,18 @@ def test_export_latest_report_no_files(tmp_path):
         assert "No diagnostic reports found" in str(e)
     else:
         assert False, "Expected FileNotFoundError"
+
+
+def test_render_pdf_missing_binary(tmp_path, monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise OSError("not found")
+
+    monkeypatch.setattr(report_renderer.pdfkit, "from_string", raise_error)
+
+    try:
+        render_pdf_report({"status": "OK"}, tmp_path / "report.pdf")
+    except OSError as e:
+        assert "wkhtmltopdf not installed" in str(e)
+    else:
+        assert False, "Expected OSError"
 


### PR DESCRIPTION
## Summary
- wrap PDF export in `render_pdf_report` with a try/except
- add test that simulates missing wkhtmltopdf binary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888888359b483289e13ab49771169de