### PR TITLE
Handle upload error message

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -5,10 +5,32 @@ import json
 import sys
 from pathlib import Path
 
-from PySide6.QtCore import QObject, Slot, Signal, QUrl, QThread
-from PySide6.QtGui import QDesktopServices
-from PySide6.QtWidgets import QApplication
-from PySide6.QtQml import QQmlApplicationEngine
+try:  # pragma: no cover - optional GUI dependencies
+    from PySide6.QtCore import QObject, Slot, Signal, QUrl, QThread
+    from PySide6.QtGui import QDesktopServices
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtQml import QQmlApplicationEngine
+except Exception:  # PySide6 may be missing or fail to load
+    QObject = object
+    def Slot(*args, **kwargs):  # type: ignore[misc]
+        def decorator(func):
+            return func
+        return decorator
+    class Signal:  # minimal stub for tests
+        def __init__(self, *a, **k):
+            pass
+        def connect(self, *a, **k):  # pragma: no cover - dummy
+            pass
+        def emit(self, *a, **k):  # pragma: no cover - dummy
+            pass
+    QUrl = type("QUrl", (), {})  # type: ignore[misc]
+    QThread = object
+    class QDesktopServices:  # type: ignore[misc]
+        @staticmethod
+        def openUrl(url):
+            pass
+    QApplication = None
+    QQmlApplicationEngine = None
 
 from cc_diagnostics import diagnostics
 from cc_diagnostics.report_renderer import export_latest_report

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cc_diagnostics import diagnostics
+
+
+def test_upload_report_success(monkeypatch):
+    def fake_open(req, timeout=10):
+        return None
+
+    monkeypatch.setattr(diagnostics.request, "urlopen", fake_open)
+    ok, err = diagnostics._upload_report("http://example.com", {"a": 1})
+    assert ok is True
+    assert err is None
+
+
+def test_upload_report_failure(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(diagnostics.request, "urlopen", raise_error)
+    ok, err = diagnostics._upload_report("http://example.com", {"a": 1})
+    assert ok is False
+    assert "boom" in err


### PR DESCRIPTION
## Summary
- return detailed exception info in `_upload_report`
- display upload failures in CLI/GUI progress messages
- stub out PySide6 for headless test environments
- test upload utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891436e720832887ce818cb240a22e