### PR TITLE
Fix Styles singleton registration

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -9,7 +9,7 @@ try:  # pragma: no cover - optional GUI dependencies
     from PySide6.QtCore import QObject, Slot, Signal, QUrl, QThread
     from PySide6.QtGui import QDesktopServices
     from PySide6.QtWidgets import QApplication
-    from PySide6.QtQml import QQmlApplicationEngine
+    from PySide6.QtQml import QQmlApplicationEngine, qmlRegisterSingletonType
 except Exception:  # PySide6 may be missing or fail to load
     QObject = object
     def Slot(*args, **kwargs):  # type: ignore[misc]
@@ -31,6 +31,8 @@ except Exception:  # PySide6 may be missing or fail to load
             pass
     QApplication = None
     QQmlApplicationEngine = None
+    def qmlRegisterSingletonType(*args, **kwargs):  # type: ignore[misc]
+        return 0
 
 from cc_diagnostics import diagnostics
 from cc_diagnostics.report_renderer import export_latest_report
@@ -168,6 +170,12 @@ def main() -> None:
     engine = QQmlApplicationEngine()
     controller = DiagnosticController()
     engine.rootContext().setContextProperty("diagnostics", controller)
+
+    styles_path = Path(__file__).parent / "ui" / "Styles.qml"
+    qmlRegisterSingletonType(
+        QUrl.fromLocalFile(str(styles_path.resolve())),
+        "App.Styles", 1, 0, "Styles"
+    )
 
     qml_path = Path(__file__).parent / "ui" / "Main.qml"
     engine.load(qml_path.as_posix())

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import "Styles.qml" as Styles
+import App.Styles 1.0
 import "."
 
 ApplicationWindow {

--- a/ui/Recommendations.qml
+++ b/ui/Recommendations.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import "Styles.qml" as Styles
+import App.Styles 1.0
 
 Column {
     id: root

--- a/ui/ReportView.qml
+++ b/ui/ReportView.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import "Styles.qml" as Styles
+import App.Styles 1.0
 
 Page {
     id: root

--- a/ui/SettingsDialog.qml
+++ b/ui/SettingsDialog.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import "Styles.qml" as Styles
+import App.Styles 1.0
 
 Dialog {
     id: root

--- a/ui/StatusCard.qml
+++ b/ui/StatusCard.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import "Styles.qml" as Styles
+import App.Styles 1.0
 
 Rectangle {
     id: card

--- a/ui/Styles.qml
+++ b/ui/Styles.qml
@@ -1,3 +1,4 @@
+pragma Singleton
 import QtQuick
 import QtQuick.Controls
 


### PR DESCRIPTION
## Summary
- mark `Styles.qml` as a QML singleton
- register the singleton from `gui.py`
- update all QML files to import the new `App.Styles` module

## Testing
- `python gui.py` *(fails: TypeError: 'NoneType' object is not callable)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889253888b08328bcb150e6f9a67629