### PR TITLE
Fix QML startup errors

### DIFF
--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts 1.15
 import App.Styles 1.0
 import "."
 

--- a/ui/StatusCard.qml
+++ b/ui/StatusCard.qml
@@ -5,7 +5,7 @@ import App.Styles 1.0
 Rectangle {
     id: card
     radius: 6
-    color: Qt.application.palette.base
+    color: Qt.application.palette ? Qt.application.palette.base : "white"
     border.color: Styles.primaryColor
 
     property bool loading: false


### PR DESCRIPTION
## Summary
- enable layout types in QML
- avoid palette errors when running offscreen

## Testing
- `pytest -q`
- `QT_QPA_PLATFORM=offscreen timeout 2 python gui.py`

------
https://chatgpt.com/codex/tasks/task_e_688927dc43d48328a843556ce9083fff